### PR TITLE
feat: retain queue position after disconnect

### DIFF
--- a/src/main/java/codes/dreaming/dreamingQueue/ConfigHelper.java
+++ b/src/main/java/codes/dreaming/dreamingQueue/ConfigHelper.java
@@ -68,4 +68,12 @@ public class ConfigHelper {
     public int getGracePriority() throws SerializationException {
         return configData.node("gracePriority").getInt(1000);
     }
+
+    public boolean isRetainExactPosition() throws SerializationException {
+        return configData.node("retainExactPosition").getBoolean(true);
+    }
+
+    public int getPositionExpirationMinutes() throws SerializationException {
+        return configData.node("positionExpirationMinutes").getInt(10);
+    }
 }

--- a/src/main/java/codes/dreaming/dreamingQueue/DreamingQueue.java
+++ b/src/main/java/codes/dreaming/dreamingQueue/DreamingQueue.java
@@ -44,6 +44,13 @@ public class DreamingQueue {
     public static void requeuePlayer(Player player) throws SerializationException {
         DreamingQueue.INSTANCE.handleAlreadyInPlayerRequeue(player);
     }
+    
+    /**
+     * Force a refresh of all player queue boss bars
+     */
+    public void forceRefreshBossBars() {
+        DreamingQueue.INSTANCE.forceRefreshBossBars();
+    }
 
     @Inject
     public DreamingQueue(ProxyServer server, Logger logger) {
@@ -83,6 +90,14 @@ public class DreamingQueue {
         CommandMeta manageQueueCommandMeta = commandManager.metaBuilder("manageQueue").plugin(this).build();
         BrigadierCommand manageQueueCommand = new BrigadierCommand(BrigadierCommand.literalArgumentBuilder("manageQueue")
                 .requires(source -> source.hasPermission(PLUGIN_ID + ".manageQueue"))
+                .then(BrigadierCommand.literalArgumentBuilder("refreshBossBars")
+                        .executes(context -> {
+                            CommandSource source = context.getSource();
+                            DreamingQueue.INSTANCE.forceRefreshBossBars();
+                            source.sendMessage(Component.text("Queue boss bars have been refreshed"));
+                            return Command.SINGLE_SUCCESS;
+                        })
+                )
                 .then(BrigadierCommand.literalArgumentBuilder("removeFromGrace")
                         .then(BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
                                 .suggests((context, builder) -> {

--- a/src/main/java/codes/dreaming/dreamingQueue/DreamingQueueEventHandler.java
+++ b/src/main/java/codes/dreaming/dreamingQueue/DreamingQueueEventHandler.java
@@ -217,18 +217,34 @@ public class DreamingQueueEventHandler {
         try {
             int activeTotal = queuedPlayers.size();
             
-            // Count ghost positions from players with saved positions
-            int ghostPositions = 0;
+            // Get ghost positions from players with saved positions
+            List<Integer> ghostPositions = new ArrayList<>();
             if (configHelper.isRetainExactPosition()) {
-                ghostPositions = (int) leftPositionPlayers.size();
+                for (DisconnectedQueuePlayer ghostPlayer : leftPositionPlayers.asMap().values()) {
+                    ghostPositions.add(ghostPlayer.getPosition());
+                }
+                // Sort the ghost positions
+                Collections.sort(ghostPositions);
             }
             
-            int totalWithGhosts = activeTotal + ghostPositions;
+            int totalWithGhosts = activeTotal + ghostPositions.size();
             
+            // Calculate actual positions accounting for ghost positions
             for (int i = 0; i < activeTotal; i++) {
                 QueuedPlayer qp = queuedPlayers.get(i);
-                int position = i + 1;
-                BossBar bar = buildBossBar(position, totalWithGhosts);
+                
+                // Count how many ghost positions are before this player
+                int ghostsBefore = 0;
+                for (Integer ghostPos : ghostPositions) {
+                    if (ghostPos <= i) {
+                        ghostsBefore++;
+                    }
+                }
+                
+                // The actual position is the index + 1 + number of ghosts before this player
+                int actualPosition = i + 1 + ghostsBefore;
+                
+                BossBar bar = buildBossBar(actualPosition, totalWithGhosts);
                 qp.paintBossBar(bar);
             }
         } catch (Exception e) {

--- a/src/main/java/codes/dreaming/dreamingQueue/DreamingQueueEventHandler.java
+++ b/src/main/java/codes/dreaming/dreamingQueue/DreamingQueueEventHandler.java
@@ -167,25 +167,16 @@ public class DreamingQueueEventHandler {
             .expireAfterWrite(configHelper.getPositionExpirationMinutes(), TimeUnit.MINUTES)
             .removalListener(notification -> {
                 try {
-                    // Schedule the bossbar update on the main server thread to ensure consistency
-                    proxyServer.getScheduler().buildTask(pluginInstance, () -> {
-                        try {
-                            DisconnectedQueuePlayer expiredPlayer = (DisconnectedQueuePlayer) notification.getValue();
-                            logger.info(MessageFormat.format(
-                                "Reserved position for player {0} expired after {1} minutes", 
-                                expiredPlayer.getPlayer().getUsername(), 
-                                configHelper.getPositionExpirationMinutes()
-                            ));
-                            
-                            synchronized (queueLock) {
-                                updateBossBarsInternal();
-                            }
-                        } catch (Exception e) {
-                            logger.warning("Error updating boss bars on expiration: " + e.getMessage());
-                        }
-                    }).schedule();
+                    DisconnectedQueuePlayer expiredPlayer = (DisconnectedQueuePlayer) notification.getValue();
+                    logger.info(MessageFormat.format(
+                        "Reserved position for player {0} expired after {1} minutes", 
+                        expiredPlayer.getPlayer().getUsername(), 
+                        configHelper.getPositionExpirationMinutes()
+                    ));
+                    
+                    forceRefreshBossBars();
                 } catch (Exception e) {
-                    // Ignore exceptions during removal
+                    logger.warning("Error updating boss bars on expiration: " + e.getMessage());
                 }
             })
             .build();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,3 +3,5 @@ targetServer: "main"
 maxPlayers: 100
 graceMinutes: 5
 gracePriority: 1000
+retainExactPosition: true
+positionExpirationMinutes: 10


### PR DESCRIPTION
- Added ability to retain exact queue position when a player disconnects
- Position is stored for a configurable amount of time
- Player is placed at their previous position or as close as possible on reconnect
- Added configuration options to enable/disable and set expiration time